### PR TITLE
Preparação para o ambiente AWS

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+# valores usados para o deploy
+PLATFORM=linux/arm64
+ECR_REPO_BASE=jardinetes-ct
+ECR_URI=279634266618.dkr.ecr.sa-east-1.amazonaws.com
+NODE_VERSION=18

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
+# Usa a versão mais recente, caso não seja especificada
+ARG NODE_VERSION=latest
+
 # Usa a imagem leve do Node.js
-FROM node:18-alpine
+FROM node:${NODE_VERSION}
 
 # Define o diretório de trabalho dentro do container
 WORKDIR /app
 
 # Copia os arquivos essenciais primeiro
-COPY package.json package-lock.json ./ 
+COPY package.json package-lock.json ./
 
 # Instala as dependências
 RUN npm install --legacy-peer-deps --omit=dev

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,17 @@
+name: jardinetes-ct
+
+services:
+  jardinetes:
+    container_name: jardinetes-ct
+    image: "${COMPOSE_PROJECT_NAME}:node-${NODE_VERSION}"
+    build:
+      context: .
+      args:
+        PLATFORM: ${PLATFORM}
+        PROJECT: ${COMPOSE_PROJECT_NAME}
+        NODE_VERSION: ${NODE_VERSION}
+    ports:
+      - "8080:8081"
+    env_file:
+      - path: env/${COMPOSE_PROJECT_NAME}.env
+        required: true

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Carrega a imagem no ECR
+# A imagem preferencial usada no ECS será aquela com tag latest
+
+PROJECT=$1
+
+if [ -z ${PROJECT} ]; then
+    echo "Uso: deploy.sh <nome_do_projeto>"
+    echo "Erro: Nome do projeto não informado"
+    exit 1
+fi
+
+PROJECT_ENV=env/${PROJECT}.env
+
+if [ ! -r ${PROJECT_ENV} ]; then
+    echo "Erro: Arquivo ${PROJECT_ENV} não existe ou não é legível"
+    exit 2
+fi
+
+source .env
+source ${PROJECT_ENV}
+
+export ECR_REPO=${ECR_REPO_BASE}
+ECR_REPO_URI=${ECR_URI}/${ECR_REPO}
+TAGS="node-${NODE_VERSION} latest"
+
+# algumas variáveis de ambiente precisam ser passados ao compose
+export NODE_VERSION
+docker compose -p ${PROJECT} build
+
+# aplica os tags à imagem
+for t in $TAGS; do
+    docker tag ${ECR_REPO}:node-${NODE_VERSION} ${ECR_REPO_URI}:${t}
+done
+
+# autentica no ECR e faz o upload da imagem
+docker push --all-tags ${ECR_REPO_URI}

--- a/env/jardinetes-ct.env
+++ b/env/jardinetes-ct.env
@@ -1,0 +1,1 @@
+# Variáveis de ambiente necessárias para a execução da aplicação


### PR DESCRIPTION
Foram incluídas configurações e scripts para preparar o contêiner para publicação no ambiente da AWS.

Para criar a imagem:
`$ docker compose -p jardinetes-ct build`

Deve ser possível executar a aplicação executando:
`$ docker compose up -d`

Para publicar a imagem:
`$ ./deploy.sh jardinetes-ct`

Atentar para o seguinte:

- O build da imagem está apresentado erros que precisam ser corrigidos
- Avaliar a atualização do Node para a versão 23. A versão 18 está muito desatualizada
- Caso a aplicação seja totalmente estática, poderá ser publicada no serviço S3 ao invés do ECS
- Ainda não foi concedida permissão de push, portanto, a última fase do deploy.sh falhará. Assim que o build e up estiverem corretos, daremos continuidade com a concessão das permissões necessárias seja no S3 ou ECS, de acordo com a solução mais adequada.