### PR TITLE
Ajustes para site estático

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,3 @@
 # valores usados para o deploy
 PLATFORM=linux/amd64
-ECR_REPO_BASE=jardinetes-ct
-ECR_URI=279634266618.dkr.ecr.sa-east-1.amazonaws.com
 NODE_VERSION=23

--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # valores usados para o deploy
-PLATFORM=linux/arm64
+PLATFORM=linux/amd64
 ECR_REPO_BASE=jardinetes-ct
 ECR_URI=279634266618.dkr.ecr.sa-east-1.amazonaws.com
 NODE_VERSION=23

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,8 @@ services:
     image: "${COMPOSE_PROJECT_NAME}:node-${NODE_VERSION}"
     build:
       context: .
+      platforms:
+        - ${PLATFORM}
       args:
         PLATFORM: ${PLATFORM}
         PROJECT: ${COMPOSE_PROJECT_NAME}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-# Carrega a imagem no ECR
-# A imagem preferencial usada no ECS será aquela com tag latest
+# Carrega o site estático no S3
 
 PROJECT=$1
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,18 +20,14 @@ fi
 source .env
 source ${PROJECT_ENV}
 
-export ECR_REPO=${ECR_REPO_BASE}
-ECR_REPO_URI=${ECR_URI}/${ECR_REPO}
-TAGS="node-${NODE_VERSION} latest"
-
 # algumas variáveis de ambiente precisam ser passados ao compose
 export NODE_VERSION
 docker compose -p ${PROJECT} build
 
-# aplica os tags à imagem
-for t in $TAGS; do
-    docker tag ${ECR_REPO}:node-${NODE_VERSION} ${ECR_REPO_URI}:${t}
-done
-
-# autentica no ECR e faz o upload da imagem
-docker push --all-tags ${ECR_REPO_URI}
+# executa o contêiner e copia os arquivos para o bucket S3
+docker compose up -d
+rm -rf ./dist
+docker cp jardinetes-ct:/app/web-build ./dist
+docker compose down
+aws s3 rm s3://${S3_BUCKET} --recursive
+aws s3 cp ./dist/ s3://${S3_BUCKET}/ --recursive

--- a/deploy.sh
+++ b/deploy.sh
@@ -19,7 +19,7 @@ fi
 source .env
 source ${PROJECT_ENV}
 
-# algumas variáveis de ambiente precisam ser passados ao compose
+# algumas variáveis de ambiente precisam ser passadas ao compose
 export NODE_VERSION
 docker compose -p ${PROJECT} build
 

--- a/env/jardinetes-ct.env
+++ b/env/jardinetes-ct.env
@@ -1,1 +1,2 @@
-# Variáveis de ambiente necessárias para a execução da aplicação
+# Variáveis de ambiente deste projeto
+S3_BUCKET=jardinetes.ct.utfpr.edu.br

--- a/scripts/utfpr/.utfpr/aws-idp-auth.conf
+++ b/scripts/utfpr/.utfpr/aws-idp-auth.conf
@@ -1,0 +1,21 @@
+# Configurações usadas pelo script aws-auth.sh
+# Autor: Wilson Horstemyer Bogado <wilson@utfpr.edu.br>
+
+# As variáveis que já tenham valor definido manterão o valor,
+# caso contrário receberão o valor padrão.
+
+# Região usada pelas chamadas às APIs da AWS
+# Esta variável precisa ser exportada
+AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-sa-east-1}
+
+# Parâmetros para conexão ao provedor de identidade
+CLIENT_ID=${CLIENT_ID:-utfpr-ct-cogeti-cloud}
+OIDC_TOKEN_ENDPOINT=${OIDC_TOKEN_ENDPOINT:-https://sso.ct.utfpr.edu.br/realms/UTFPR/protocol/openid-connect/token}
+OIDC_LOGOUT_ENDPOINT=${OIDC_LOGOUT_ENDPOINT:-https://sso.ct.utfpr.edu.br/realms/UTFPR/protocol/openid-connect/logout}
+
+# Lista de escopos usados na obtenção do token OIDC
+# No mínimo, o escopo openid precisa estar presente para obter o ID token
+OIDC_SCOPE=${OIDC_SCOPE:-"openid"}
+
+# A função (role) que o usuário assumirá
+ROLE_ARN=${ROLE_ARN:-arn:aws:iam::279634266618:role/UTFPR-USER-Access}

--- a/scripts/utfpr/.utfpr/aws-idp-auth.inc
+++ b/scripts/utfpr/.utfpr/aws-idp-auth.inc
@@ -1,0 +1,119 @@
+# Obtém as credenciais temporárias e assume a função que permite
+# executar chamadas às APIs da AWS
+# Parâmetros:
+#   $1: ARN da função (role) a ser assumida
+#   $2: Nome do usuário federado
+#   $3: ID Token do provedor de identidade
+get_aws_access_key() {
+    local role_arn=$1
+    local username=$2
+    local id_token=$3
+
+    aws sts assume-role-with-web-identity \
+        --role-arn "${role_arn}" \
+        --role-session-name "${username}" \
+        --web-identity-token "${id_token}"
+}
+
+# Obtem um novo token a partir do refresh token
+# Parâmetros:
+#   $1: ID do client OIDC
+#   $2: Escopo(s) da resposta do provedor OIDC
+#   $3: URL para obtenção de token de identidade OIDC
+#   $4: Refresh token do provedor de identidade
+refresh_token() {
+    local client_id=$1
+    local oidc_scope=$2
+    local oidc_token_endpoint=$3
+    local refresh_token=$4
+
+    curl -s \
+        -d "client_id=${client_id}" \
+        -d "scope=${oidc_scope}" \
+        -d "grant_type=refresh_token" \
+        -d "refresh_token=${refresh_token}" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -X POST "${oidc_token_endpoint}"
+}
+
+# Obtém o token do provedor de identidade
+# O token precisa conter o id_token o que exige o escopo openid
+# Ver: https://stackoverflow.com/questions/73334996/personal-access-tokens-with-keycloak
+# Parâmetros:
+#   $1: ID do cliente OIDC
+#   $2: Escopo(s) da resposta do provedor OIDC
+#   $3: Nome do usuário federado
+#   $4: Senha do usuário federado
+#   $5: URL para obtenção de token OIDC
+get_oidc_token() {
+    local client_id=$1
+    local oidc_scope=$2
+    local username=$3
+    local password=$4
+    local oidc_token_endpoint=$5
+
+    curl -s \
+        -d "client_id=${client_id}" \
+        -d "scope=${oidc_scope}" \
+        -d "username=${username}" \
+        --data-urlencode "password=${password}" \
+        -d "grant_type=password" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -X POST "${oidc_token_endpoint}"
+}
+
+
+# Extrai o access token
+# Parâmetros:
+#   $1: O token OIDC do usuário logado
+#   $2: O nome do valor a ser extraído
+get_oidc_value() {
+    local oidc_token=$1
+    local token_value_name=$2
+
+    jq -r ."${token_value_name}" <<< ${oidc_token}
+}
+
+# Extrai o ID token
+# Parâmetros:
+#   $1: O token OIDC do usuário logado
+get_oidc_id_token() {
+    local oidc_token=$1
+
+    get_oidc_value "${oidc_token}" "id_token"
+}
+
+# Extrai o acess token
+# Parâmetros:
+#   $1: O token OIDC do usuário logado
+get_oidc_access_token() {
+    local oidc_token=$1
+
+    get_oidc_value "${oidc_token}" "access_token"
+}
+
+# Extrai o refresh token
+# Parâmetros:
+#   $1: O token OIDC do usuário logado
+get_oidc_refresh_token() {
+    local oidc_token=$1
+
+    get_oidc_value "${oidc_token}" "refresh_token"
+}
+
+# Encerra a sessão com o provedor de identidade OIDC
+# Parâmetros:
+#   $1: ID do cliente OIDC
+#   $2: ID token do usuário
+#   $3: URL para de logout OIDC
+oidc_logout() {
+    local client_id=$1
+    local id_token=$2
+    local oidc_logout_endpoint=$3
+
+    curl -s \
+        -d "client_id=${client_id}" \
+        -d "id_token_hint=${id_token}" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -X POST "${oidc_logout_endpoint}"
+}

--- a/scripts/utfpr/aws-idp-auth.sh
+++ b/scripts/utfpr/aws-idp-auth.sh
@@ -91,7 +91,7 @@ fi
 
 # Gera comandos export na saída padrao
 # Para injetar as variáveis em um terminal interativo ou script, p. ex.:
-#   eval $(./aws-auth.sh)
+#   eval $(./aws-idp-auth.sh)
 cat > /dev/stdout <<EOF
 export AWS_ACCESS_KEY_ID=$(jq -r .Credentials.AccessKeyId <<< $AWS_CREDS)
 export AWS_SECRET_ACCESS_KEY=$(jq -r .Credentials.SecretAccessKey <<< $AWS_CREDS)

--- a/scripts/utfpr/aws-idp-auth.sh
+++ b/scripts/utfpr/aws-idp-auth.sh
@@ -10,7 +10,7 @@
 #                        sem reautenticar (quando disponível)
 #   OIDC_SCOPE: escopos a serem usados para obteção do token OIDC
 # Para usar estas variáveis em um terminal interativo ou script:
-#   $ eval $(./aws-auth.sh)
+#   $ eval $(./aws-idp-auth.sh)
 # Autor: Wilson Horstmeyer Bogado <wilson@utfpr.edu.br>
 
 # Para executar este script são necessários alguns programas auxiliares:
@@ -36,7 +36,7 @@ fi
 
 source ${CONFFILE}
 
-# Caso não seja informado usa o nome de usuário logado
+# Caso não seja informado, usa o nome de usuário logado
 USERNAME=${1:-${UTFPR_USERNAME:-$USER}}
 
 # Obtém a senha do usuário para autenticação via OIDC

--- a/scripts/utfpr/aws-idp-auth.sh
+++ b/scripts/utfpr/aws-idp-auth.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Obtém credenciais temporárias para um usuário federado.
+# Gera uma sequência de comandos export para as variáveis de ambiente
+# usadas por padrão pelas APIs da AWS.
+#
+# Variáveis de ambiente
+#   UTFPR_USERNAME: nome de usuário federado
+#   UTFPR_PASSWORD: senha do usuário federado
+#   UTFPR_REFRESH_TOKEN: token que permite obter novas credenciais
+#                        sem reautenticar (quando disponível)
+#   OIDC_SCOPE: escopos a serem usados para obteção do token OIDC
+# Para usar estas variáveis em um terminal interativo ou script:
+#   $ eval $(./aws-auth.sh)
+# Autor: Wilson Horstmeyer Bogado <wilson@utfpr.edu.br>
+
+# Para executar este script são necessários alguns programas auxiliares:
+#   - curl
+#   - jq
+#
+# Por exemplo para Ubuntu/Debian:
+#   sudo apt -y install curl jq
+# A maioria das distribuições já vem com curl instalado
+#
+# Também é necessário instalar o AWS CLI:
+#   https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+
+# Define funções de suporte
+source  ~/.utfpr/aws-idp-auth.inc
+
+# Variáveis de ambiente contendo parâmetros para este script
+CONFFILE=~/.utfpr/aws-idp-auth.conf
+if [ ! -r ${CONFFILE} ]; then
+    echo "Arquivo de configuração ${CONFFILE} não existe ou não é legível"
+    exit 1
+fi
+
+source ${CONFFILE}
+
+# Caso não seja informado usa o nome de usuário logado
+USERNAME=${1:-${UTFPR_USERNAME:-$USER}}
+
+# Obtém a senha do usuário para autenticação via OIDC
+# Tenta usar o valor da variável UTFPR_PASSWORD,
+# caso não esteja definida obtém interativamente
+PASSWORD=${UTFPR_PASSWORD}
+if [ -z "${PASSWORD}" ]; then
+    read -p "[${USERNAME}] Senha: " -s PASSWORD
+    echo
+fi
+
+# Obtém o token do provedor de identidade
+# O token precisa conter o id_token o que exige o escopo openid
+# O escopo offline_access faz com que o refresh token seja incluído na resposta
+# Ver: https://stackoverflow.com/questions/73334996/personal-access-tokens-with-keycloak
+OIDC_TOKEN=$(get_oidc_token \
+    "${CLIENT_ID}" \
+    "${OIDC_SCOPE}" \
+    "${USERNAME}" \
+    "${PASSWORD}" \
+    "${OIDC_TOKEN_ENDPOINT}" \
+)
+
+if [ -n "${DEBUG}" ]; then
+    jq <<< ${OIDC_TOKEN}
+fi
+
+# Extrai o token usado nas chamadas às APIs da AWS
+# Aborta em caso de usuário e/ou senha incorretos
+ID_TOKEN=$(get_oidc_id_token "${OIDC_TOKEN}")
+if [ "$ID_TOKEN" == "null" ]; then
+    jq <<< ${OIDC_TOKEN}
+    exit 2
+fi
+
+# Extrai o refresh token necessário para gerar um novo token
+# caso o inicial expire
+REFRESH_TOKEN=$(get_oidc_refresh_token "${OIDC_TOKEN}")
+if [ "${REFRESH_TOKEN}" == "null" ]; then
+    jq <<< ${OIDC_TOKEN}
+    exit 3
+fi
+
+# Obtém as credenciais temporárias e assume a função que permite
+# executar chamadas às APIs da AWS
+AWS_CREDS=$(get_aws_access_key "${ROLE_ARN}" "${USERNAME}" "${ID_TOKEN}")
+
+if [ -z "${AWS_CREDS}" ]; then
+    echo "Não foi possível obter credenciais temporárias"
+    exit 4
+fi
+
+# Gera comandos export na saída padrao
+# Para injetar as variáveis em um terminal interativo ou script, p. ex.:
+#   eval $(./aws-auth.sh)
+cat > /dev/stdout <<EOF
+export AWS_ACCESS_KEY_ID=$(jq -r .Credentials.AccessKeyId <<< $AWS_CREDS)
+export AWS_SECRET_ACCESS_KEY=$(jq -r .Credentials.SecretAccessKey <<< $AWS_CREDS)
+export AWS_SESSION_TOKEN=$(jq -r .Credentials.SessionToken <<< $AWS_CREDS)
+export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
+export OIDC_ID_TOKEN=${ID_TOKEN}
+export OIDC_REFRESH_TOKEN=${REFRESH_TOKEN}
+EOF


### PR DESCRIPTION
**Constatado que se trata de site estático**, os procedimentos e scripts foram ajustados para publicação no S3.
O uso dos scripts requer a instalação de alguns pacotes do sistema operacional, por exemplo, no Ubuntu/Debian:

`# apt -y install curl jq`

Também é necessário instalar o AWS CLI. Instruções aqui:
https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html

O script de autenticação foi pensado para ser instalado no diretório home do usuário, para tanto:
`$ cp -rf scripts/utfpr/* scripts/utfpr/.* ~`

**Como usar:**

```
$ export UTFPR_USERNAME=nome-de-usuario
$ export UTFPR_PASSWORD='senha-do-usuario'

$ eval $(~/aws-idp-auth.sh)
$ ./deploy.sh jardinetes-ct
```

**Observações:**

- Mais detalhes sobre o funcionamento dos scripts estão comentados no próprio arquivo
- Caso as variáveis de ambiente `UTFPR_USERNAME` e/ou `UTFPR_PASSWORD` não sejam exportadas, usuário e senha serão solicitados interativamente
- Atualmente somente o Victor está autorizado no bucket S3. O usuário é o do sistema corporativo/acadêmico
- Caso desejem que outros usuários tenham acesso ao S3, deverá ser solicitado pelo coordenador do projeto via sistema de chamados da COGETI
- Eventualmente o `Dockerfile` pode ser otimizado para tornar a criação da imagem mais rápida
